### PR TITLE
Minor Bug fix due to { } in prints

### DIFF
--- a/scripts/files/index_html.py
+++ b/scripts/files/index_html.py
@@ -81,7 +81,7 @@ def show_index_html(error_code):
                             </div>
                         </main>
                     </atricle>
-                    <h2>{0}</h2>
+                    <h2>%s</h2>
                 </section>
                 <section class="aside-section">
                     <aside>
@@ -120,6 +120,6 @@ def show_index_html(error_code):
         </script>
     </body>
 </html>
-""" .format(error_text))
+""" %(error_text))
 
     return


### PR DESCRIPTION
The introduction of functions in html will cause the string insertion with
f"text{var}" OR
"text{0}" .format(var)
to fail. Trying the oldschool %s here